### PR TITLE
build: multi-stage Dockerfile, compose setup, dev workflow, and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copy this file to .env and fill in the values.
+# .env is git-ignored so your local settings won't be committed.
+
+# Host path to the directory containing your ezbeq.yml.
+# Defaults to ~/.ezbeq if not set.
+# EZBEQ_CONFIG_HOME=/path/to/your/config
+
+# Port — must match the 'port:' value in ezbeq.yml (default: 8080)
+# EZBEQ_PORT=8080
+
+# --- Local development only (required for bin/run-local) ---
+
+# Path to your local ezbeq source tree or worktree
+# EZBEQ_SRC=/path/to/ezbeq

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,0 +1,90 @@
+# Builds a dev image from source (ezbeq + ezbeq-docker checked out together).
+#
+# Unlike publish.yaml (which installs ezbeq from PyPI into a production image),
+# this workflow builds the `dev` Dockerfile target: it checks out the matching
+# branch of <owner>/ezbeq as the build context, runs a full Poetry install, and
+# compiles the React UI from source.
+#
+# Branch matching: the ezbeq branch is resolved to the same name as the branch
+# that triggered this workflow. If no matching branch exists in <owner>/ezbeq
+# (e.g. an ezbeq-docker-only branch), it falls back to the production target,
+# which installs ezbeq from PyPI — identical to publish.yaml.
+#
+# Images are tagged:  ghcr.io/<owner>/ezbeq-docker:dev  (always overwritten)
+
+name: Create and publish a dev Docker image (built from source)
+
+on:
+  push:
+    branches: ['dev']  # only when commits land on the dev branch
+    paths-ignore:
+      - 'README.md'
+  workflow_dispatch:  # manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve ezbeq branch (fallback to production/PyPI)
+        id: ezbeq-ref
+        run: |
+          if git ls-remote --exit-code --heads \
+              "https://github.com/${{ github.repository_owner }}/ezbeq.git" \
+              "${{ github.ref_name }}" > /dev/null 2>&1; then
+            echo "ref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "target=dev" >> $GITHUB_OUTPUT
+            echo "context=./ezbeq-src" >> $GITHUB_OUTPUT
+          else
+            echo "ref=" >> $GITHUB_OUTPUT
+            echo "target=production" >> $GITHUB_OUTPUT
+            echo "context=." >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout ezbeq source (${{ steps.ezbeq-ref.outputs.ref }})
+        if: steps.ezbeq-ref.outputs.target == 'dev'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/ezbeq
+          ref: ${{ steps.ezbeq-ref.outputs.ref }}
+          path: ezbeq-src
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ steps.ezbeq-ref.outputs.context }}
+          file: ./Dockerfile
+          target: ${{ steps.ezbeq-ref.outputs.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,21 @@
-# Build stage: Used to prepare the application with all necessary tools and dependencies
-# Using python:3.13-slim-trixie for linux/amd64 to support minidsp requiring glibc >= 2.32
-FROM python:3.13-slim-trixie AS builder
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build with four targets:
+#
+#   base        – shared OS packages + minidsp binary (not used directly)
+#   builder     – production Python venv built from requirements.txt
+#   production  – default; clean runtime image with non-root user.
+#                 Built by CI / docker buildx bake.
+#   dev         – local development; Poetry + Node/Yarn, builds React UI.
+#                 Used by bin/run-local via docker-compose.override.yaml.
 
-# Set the working directory inside the container
-WORKDIR /app
-
-# Install dependencies required for building the application
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    # Tools for compiling and building packages
-    build-essential \
-    # Utility for downloading files
-    curl \
-    # Python virtual environment creation tool
-    python3-venv && \
-    python -m pip install --upgrade pip  # Upgrade pip to the latest version
-
-# Create a Python virtual environment at /opt/venv
-RUN python -m venv /opt/venv
-
-# Add the virtual environment to the PATH
-ENV PATH="/opt/venv/bin:${PATH}"
-
-# Copy the Python requirements file into the container
-COPY requirements.txt ./
-
-# Install the Python dependencies listed in requirements.txt
-RUN pip install --pre --no-cache-dir -r requirements.txt
-
-# Runtime stage: A clean, lightweight image for running the application
-FROM python:3.13-slim-trixie
+# ── Base: runtime OS + minidsp binary ────────────────────────────────────────
+# Shared by both the production and dev build targets.
+# python:3.13-slim-trixie — Debian 13 (stable), native Python 3.13, glibc 2.40
+FROM python:3.13-slim-trixie AS base
 
 # Set the environment variable for ezbeq configuration
 ENV EZBEQ_CONFIG_HOME=/config
-
-# Copy the Python virtual environment prepared in the build stage
-# This brings only the necessary runtime dependencies from the build stage.
-COPY --from=builder /opt/venv /opt/venv
-
-# Set the working directory inside the container
-WORKDIR /app
-
-# Define a volume for configuration data
-VOLUME ["/config"]
-
-# Add the virtual environment to the PATH
-ENV PATH="/opt/venv/bin:${PATH}"
 
 # Install runtime-only dependencies required by the application
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -52,8 +23,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     curl \
     # SQLite database command-line tool
     sqlite3 \
-    # minidsp binary is dynamically linked against libusb-1.0.so.0 and expects it to be available in the environment, even if the functionality it provides (USB communication) isn’t being used
-    libusb-1.0-0
+    # minidsp is dynamically linked against libusb-1.0.so.0 and expects it to be
+    # available in the environment, even if USB communication isn't being used
+    libusb-1.0-0 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Dynamically download and install the correct minidsp binary based on architecture
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -67,20 +40,120 @@ RUN ARCH=$(dpkg --print-architecture) && \
     curl -L -o minidsp.${ARCH}.tar.gz "$URL" && \
     tar -xzf minidsp.${ARCH}.tar.gz && \
     mv minidsp /usr/local/bin/minidsp && \
-    chmod +x /usr/local/bin/minidsp
+    chmod +x /usr/local/bin/minidsp && \
+    rm minidsp.${ARCH}.tar.gz
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Define a volume for configuration data
+VOLUME ["/config"]
+
+# Document the default port. The actual port is set via 'port:' in ezbeq.yml
+# and must be reflected in the compose file's ports: and healthcheck: entries.
+EXPOSE 8080
+
+# ── Production builder: install Python deps into a venv ──────────────────────
+# Separate stage so build tools don't end up in the final runtime image.
+FROM base AS builder
+
+# Install dependencies required for building the application
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    # Tools for compiling and building packages
+    build-essential \
+    # Python virtual environment creation tool
+    python3-venv && \
+    python -m pip install --upgrade pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a Python virtual environment at /opt/venv
+RUN python -m venv /opt/venv
+
+# Add the virtual environment to the PATH
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Copy the Python requirements file into the container
+COPY requirements.txt ./
+
+# Install the Python dependencies listed in requirements.txt
+RUN pip install --pre --no-cache-dir -r requirements.txt
+
+# ── Production: clean runtime image ──────────────────────────────────────────
+# A clean, lightweight image for running the application.
+FROM base AS production
+
+# Copy the Python virtual environment prepared in the build stage.
+# This brings only the necessary runtime dependencies, without build tools.
+COPY --from=builder /opt/venv /opt/venv
+
+# Add the virtual environment to the PATH
+ENV PATH="/opt/venv/bin:${PATH}"
 
 # Create a non-root user and group for running the application
-RUN groupadd -r ezbeq && useradd -r -g ezbeq ezbeq
-
-# Set ownership for /app
-RUN chown -R ezbeq:ezbeq /app
+RUN groupadd -r ezbeq && useradd -r -g ezbeq ezbeq && \
+    chown -R ezbeq:ezbeq /app
 
 # Switch to the non-root user
 USER ezbeq
 
-# Define a health check for the application to verify it's running correctly
-HEALTHCHECK --interval=10s --timeout=2s \
-  CMD curl -f -s --show-error http://localhost:8080/api/1/version || exit 1
-
 # Define the default command to run the ezbeq application
-CMD [ "ezbeq" ]
+CMD ["ezbeq"]
+
+# ── UI builder: compile React app ────────────────────────────────────────────
+# Isolated Node stage so that node_modules never enters the dev image layer.
+# Only the Vite dist output (~a few MB) is copied across; the 200MB+
+# node_modules is discarded after this stage completes.
+FROM node:22-slim AS ui-builder
+
+WORKDIR /app/ui
+
+# Copy ui source — .yarnrc.yml references .yarn/releases/yarn-4.12.0.cjs so
+# the whole ui/ tree is needed.  node_modules and .yarn/cache are excluded
+# via .dockerignore so the build context stays small.
+COPY ui/ .
+
+# Mount the yarn cache at the location Yarn 4 uses when enableGlobalCache is
+# false (i.e. the project-local .yarn/cache dir).  This persists the package
+# zip archives across builds so yarn install is fast on cache hits.
+RUN --mount=type=cache,target=/app/ui/.yarn/cache \
+    yarn install --silent && yarn build
+
+# ── Dev: local source build with Poetry ──────────────────────────────────────
+# Build context is the local ezbeq source tree (set by docker-compose.local.yaml).
+# Node/Yarn are NOT needed here — the compiled UI is copied from ui-builder.
+FROM base AS dev
+
+# Install build tools needed for Poetry / native Python extensions
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    python3-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Poetry; cache pip downloads across builds
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install poetry
+
+# Keep the virtualenv inside the project directory (/app/.venv) so it ends up
+# in the image layer.  Without this, Poetry stores the venv under its cache dir
+# (~/.cache/pypoetry/virtualenvs/) which is a cache mount — not persisted in
+# the image — so the container starts with no installed packages.
+RUN poetry config virtualenvs.in-project true
+
+# Install Python deps (without the app itself yet — better layer caching,
+# this step only reruns when pyproject.toml or poetry.lock changes).
+COPY pyproject.toml poetry.lock ./
+RUN --mount=type=cache,target=/root/.cache/pypoetry/cache \
+    poetry install --no-root
+
+# Copy the compiled UI from the ui-builder stage (a few MB, not node_modules).
+# vite.config.js sets outDir: '../ezbeq/ui' relative to ui/, so output lands
+# at /app/ezbeq/ui inside the ui-builder container.
+COPY --from=ui-builder /app/ezbeq/ui ./ezbeq/ui/
+
+# Copy the full source and install the app entry point
+COPY . .
+RUN --mount=type=cache,target=/root/.cache/pypoetry/cache \
+    poetry install
+
+# Define the default command to run the ezbeq application via Poetry
+CMD ["poetry", "run", "ezbeq"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Creates and publishes an image for [ezBEQ](https://github.com/3ll3d00d/ezbeq) to
 > - [Synology NAS discussion](https://github.com/jmery/ezbeq-docker/tree/ef3f954f37b1b420e31635a699bfbb864e861ad9?tab=readme-ov-file#general-linux-docker-instructions)
 >  - [Higher privileges discussion](https://github.com/jmery/ezbeq-docker/tree/ef3f954f37b1b420e31635a699bfbb864e861ad9?tab=readme-ov-file#note-on-execute-container-using-high-privilege)
 
+## Contents
+
+- [Setup](#setup)
+- [FAQ](#faq)
+- [Running with Docker Compose](#running-with-docker-compose)
+- [Running a local branch](#running-a-local-branch)
+- [Running in Kubernetes](#running-in-kubernetes)
+- [CI / Published Images](#ci--published-images)
+- [Developer Documentation](#developer-documentation)
+
 ## Setup
 
 - Expects a volume mapped to `/config `to allow user supplied `ezbeq.yml`
@@ -36,6 +46,52 @@ The docker image get's built to target:
 
 - `linux/amd64`
 - `linux/arm64`
+
+---
+
+## Running with Docker Compose
+
+`docker compose up -d` works with no configuration — it pulls the published image and mounts `~/.ezbeq` as the config directory by default.
+
+To use a different config directory, set `EZBEQ_CONFIG_HOME` in a `.env` file (copy `.env.example`):
+
+```bash
+cp .env.example .env
+# set EZBEQ_CONFIG_HOME=/path/to/your/config
+docker compose up -d
+```
+
+[docker-compose.yaml](./docker-compose.yaml) also reads `EZBEQ_PORT` from `.env` if your `ezbeq.yml` uses a non-default port. To customise further (e.g. add `extra_hosts` for a MiniDSP hostname, change the user, mount USB devices), add a `docker-compose.override.yaml` alongside it — Docker Compose picks it up automatically.
+
+See the [ezbeq documentation](https://github.com/3ll3d00d/ezbeq) for `ezbeq.yml` configuration options.
+
+---
+
+## Running a local branch
+
+To build and run from a local ezbeq source tree (e.g. an unreleased branch):
+
+**1. Copy `.env.example` to `.env` and fill in `EZBEQ_SRC`:**
+
+```bash
+cp .env.example .env
+# edit .env — set EZBEQ_SRC to your local ezbeq checkout and EZBEQ_CONFIG_HOME to your config dir
+```
+
+**2. Run it:**
+
+```bash
+bin/run-local            # build image and start (detached)
+bin/run-local --logs     # start and follow logs
+bin/run-local --rebuild  # force a full image rebuild
+bin/run-local --stop     # stop and remove the container
+```
+
+`bin/run-local` loads `.env`, auto-detects the port from your `ezbeq.yml`, and runs:
+```
+docker compose -f docker-compose.yaml -f docker-compose.dev.yaml up --build
+```
+[docker-compose.dev.yaml](./docker-compose.dev.yaml) extends the base config with the `dev` build target, which compiles the React UI from source and installs Python deps via Poetry.
 
 ---
 
@@ -195,6 +251,27 @@ spec:
         - ezbeq.yourdomain.dev
       secretName: ezbeq-tls
 ```
+
+---
+
+## CI / Published Images
+
+Two GitHub Actions workflows publish images to `ghcr.io/<owner>/ezbeq-docker`:
+
+| Workflow | File | Trigger | Image tag | What it builds |
+|---|---|---|---|---|
+| Production | `publish.yaml` | Push to `main` | `:<branch>` (e.g. `:main`) | ezbeq installed from PyPI via `requirements.txt` — the official release |
+| Dev (from source) | `publish-dev.yaml` | Push to any branch | `:dev` | ezbeq built from source via Poetry, UI compiled from source |
+
+The dev workflow checks out the matching branch of `<owner>/ezbeq` (same name as the branch that triggered the build). If no matching branch exists it falls back to `main`, so ezbeq-docker-only branches still produce a working image.
+
+To use a dev image on a server instead of the official one, update the image tag in your `docker-compose.yaml`:
+
+```yaml
+image: ghcr.io/<owner>/ezbeq-docker:dev
+```
+
+---
 
 ## Developer Documentation
 

--- a/bin/run-local
+++ b/bin/run-local
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Build and run ezbeq from a local source tree.
+# Reads configuration from .env (copy .env.example and fill in values).
+#
+# Usage:
+#   bin/run-local               # build + start detached
+#   bin/run-local --logs        # build + start + follow logs
+#   bin/run-local --rebuild     # force clean rebuild + follow logs
+#   bin/run-local --stop        # stop and remove the container
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ── Load .env ─────────────────────────────────────────────────────────────────
+if [[ -f .env ]]; then
+    set -o allexport; source .env; set +o allexport
+fi
+
+# ── Validate ──────────────────────────────────────────────────────────────────
+if [[ -z "${EZBEQ_SRC:-}" ]]; then
+    echo "Error: EZBEQ_SRC is not set. See .env.example."; exit 1
+fi
+if [[ ! -f "$EZBEQ_SRC/pyproject.toml" ]]; then
+    echo "Error: EZBEQ_SRC=$EZBEQ_SRC does not look like an ezbeq source tree"; exit 1
+fi
+
+EZBEQ_CONFIG="${EZBEQ_CONFIG:-$HOME/.ezbeq/ezbeq.yml}"
+if [[ ! -f "$EZBEQ_CONFIG" ]]; then
+    echo "Error: config not found: $EZBEQ_CONFIG"; exit 1
+fi
+
+# ── Auto-detect port from ezbeq.yml (EZBEQ_PORT in .env overrides) ────────────
+if [[ -z "${EZBEQ_PORT:-}" ]]; then
+    EZBEQ_PORT=$(grep -E '^\s*port\s*:' "$EZBEQ_CONFIG" 2>/dev/null | head -1 \
+        | sed 's/[^:]*:[[:space:]]*//' | tr -d ' \r\n')
+    EZBEQ_PORT="${EZBEQ_PORT:-8080}"
+fi
+
+# ── Git build info (passed into container as env vars) ────────────────────────
+GIT_BRANCH=$(git -C "$EZBEQ_SRC" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+GIT_SHA=$(git -C "$EZBEQ_SRC" rev-parse --short HEAD 2>/dev/null || echo "")
+
+export EZBEQ_SRC EZBEQ_CONFIG_HOME="$(dirname "$EZBEQ_CONFIG")" EZBEQ_DOCKER_DIR="$(pwd)" EZBEQ_PORT GIT_BRANCH GIT_SHA
+
+echo "Source : $EZBEQ_SRC"
+echo "Config : $EZBEQ_CONFIG"
+echo "Port   : $EZBEQ_PORT"
+echo "Branch : ${GIT_BRANCH:-unknown}"
+echo "SHA    : ${GIT_SHA:-unknown}"
+
+# ── Run ───────────────────────────────────────────────────────────────────────
+BUILD="--build"
+case "${1:-}" in
+    --rebuild) BUILD="--build --no-cache" ;;
+    --stop)    docker compose -f docker-compose.yaml -f docker-compose.dev.yaml down; exit 0 ;;
+esac
+
+COMPOSE="docker compose -f docker-compose.yaml -f docker-compose.dev.yaml"
+
+if [[ "${1:-}" == "--logs" || "${1:-}" == "--rebuild" ]]; then
+    $COMPOSE up -d $BUILD
+    $COMPOSE logs -f
+else
+    $COMPOSE up -d $BUILD
+    echo ""
+    echo "Running at http://localhost:$EZBEQ_PORT"
+    echo "Logs: bin/run-local --logs   |   Stop: bin/run-local --stop"
+fi

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,23 @@
+# Local development compose override.
+# Used by bin/run-local via: docker compose -f docker-compose.yaml -f docker-compose.dev.yaml
+# Not loaded automatically — regular users running `docker compose up` are unaffected.
+#
+# All values are read from environment variables set in .env (copy .env.example).
+
+services:
+  ezbeq-docker:
+    build:
+      context: ${EZBEQ_SRC}
+      dockerfile: ${EZBEQ_DOCKER_DIR}/Dockerfile
+      target: dev
+    image: ezbeq-local
+    container_name: ezbeq-local
+    environment:
+      # Echo every HTTP request to stdout so it appears in `docker compose logs`.
+      - EZBEQ_ACCESS_LOG_STDOUT=1
+      # Git build info injected by bin/run-local — surfaces in the UI footer.
+      - GIT_BRANCH
+      - GIT_SHA
+    # Optional: map hostnames to IPs for your network setup
+    # extra_hosts:
+    #   - "minidsp:192.168.1.86"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,23 +1,14 @@
 services:
   ezbeq-docker:
-    image: 3ll3d00d/ezbeq-docker
+    image: ghcr.io/3ll3d00d/ezbeq-docker:main
     container_name: ezbeq
-    environment:
-      - EZBEQ_CONFIG_HOME=/config  # Set config home environment variable
-    restart: unless-stopped  # Automatically restart unless stopped manually
-
-    # To dynamically customise this compose file, you can create a docker-compose.override.yaml file in the same directory, with the settings you want
-
-    # Set the user to run as
-    # user: X:Y  # Set the user by UID:GID
-
-    # volumes:
-      # - /apps/ezbeq/config:/config  # Mount local config directory to container
-
-    # Your port mapping setting
-    # ports:
-      # - "8080:8080"
-    
-    # Optional hostname configs, depending on your ezbeq settings
-    # extra_hosts:
-      # - "minidsp:192.168.1.86"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f -s http://localhost:${EZBEQ_PORT:-8080}/api/1/version || exit 1"]
+      interval: 10s
+      timeout: 2s
+      retries: 3
+    volumes:
+      - ${EZBEQ_CONFIG_HOME:-~/.ezbeq}:/config
+    ports:
+      - "${EZBEQ_PORT:-8080}:${EZBEQ_PORT:-8080}"


### PR DESCRIPTION
## Summary

- **Multi-stage Dockerfile** with production (PyPI) and dev (source) targets, Python 3.13 on slim-trixie, separate UI build stage that keeps node_modules out of the final image
- **Docker Compose setup** - `docker-compose.yaml` for published image, `docker-compose.dev.yaml` for local source builds, `.env.example` for configuration
- **`bin/run-local`** script for testing local ezbeq branches - auto-detects port, builds dev target, supports `--logs`, `--rebuild`, `--stop`
- **README rewrite** with TOC, compose quick-start, USB/MiniDSP guide, FAQ, and CI docs
- **`publish-dev.yaml`** CI workflow - builds dev image on pushes to `dev` branch, checks out matching ezbeq branch (falls back to PyPI), tags as `:dev`

## Test plan

- [ ] `docker compose up -d` with only `docker-compose.yaml` and a populated `.env` starts the published image correctly
- [ ] `bin/run-local --logs` builds from a local ezbeq source tree, UI is accessible
- [ ] `bin/run-local --rebuild` forces a clean image rebuild
- [ ] `bin/run-local --stop` stops and removes the container
- [ ] Multi-arch build (`linux/amd64`, `linux/arm64`) succeeds via `docker buildx`
- [ ] Push to `dev` branch triggers `publish-dev.yaml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)